### PR TITLE
fix resource routes iteration

### DIFF
--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -280,6 +280,9 @@ class ASGIResource(AbstractResource):
         self._asgi_app = app
 
     def __iter__(self):
+        return self
+
+    def __next__(self):
         raise StopIteration
 
     def __len__(self):

--- a/tests/test_fastapi_integration.py
+++ b/tests/test_fastapi_integration.py
@@ -144,3 +144,11 @@ async def test_normalize_path_middleware(asgi_resource, middlewares):
                     response.raise_for_status()
 
             assert err.value.status == 404
+
+
+def test_get_routes_from_resource(asgi_resource):
+    assert len(asgi_resource) == 0
+
+    for _ in asgi_resource:
+        # Should be unreachable
+        pytest.fail('ASGIResource should not return routes during iteration')


### PR DESCRIPTION
#3 
I don't see reliable solution to extract routes from the asgi app. I think, to fix python iteration protocol should be enough for now. 