### PR TITLE
Change header keys to lowercase

### DIFF
--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -136,7 +136,7 @@ class ASGIContext:
             "path": self.request.path,
             "raw_path": raw_path.encode(),
             "query_string": self.request.query_string.encode(),
-            "headers": [hdr for hdr in self.request.raw_headers],
+            "headers": [(key.lower(), value) for key, value in self.request.raw_headers],
         }
 
         if self.is_websocket():

--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -136,7 +136,7 @@ class ASGIContext:
             "path": self.request.path,
             "raw_path": raw_path.encode(),
             "query_string": self.request.query_string.encode(),
-            "headers": [(key.lower(), value) for key, value in self.request.raw_headers],
+            "headers": [(k.lower(), v) for k, v in self.request.raw_headers],
         }
 
         if self.is_websocket():


### PR DESCRIPTION
This PR is fixing bug with size of headers keys. In specification we can find: 'Header names must be lowercased' (https://asgi.readthedocs.io/en/latest/specs/www.html)

The bug is very easy to reproduce, in demo from readme we can add one line to endpoint to print values of cookies: 

```
@asgi_app.get("/asgi")
async def root(request: ASGIRequest):
    print(request.cookies)
    return {
        "message": "Hello World",
        "root_path": request.scope.get("root_path")
    }
```
Without my PR cookies are empty (cookies are generated from 'headers' field).  