### PR TITLE
Fix readchunk call for large body without chunked encoding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
       - run: poetry run coveralls
         env:
           COVERALLS_PARALLEL: 'true'
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   finish:

--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -220,11 +220,11 @@ class ASGIContext:
                         "code": response.close_code,
                     }
 
-        chunk, more_body = await self.request.content.readchunk()
+        chunk, _ = await self.request.content.readchunk()
         return {
             "type": "http.request",
             "body": chunk,
-            "more_body": more_body,
+            "more_body": not self.request.content.at_eof(),
         }
 
     async def on_send(self, payload: Dict[str, Any]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiohttp_asgi"
-version = "0.5.1"
+version = "0.5.2"
 description = "Adapter to running ASGI applications on aiohttp"
 authors = ["Dmitry Orlov <me@mosquito.su>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiohttp_asgi"
-version = "0.5.0"
+version = "0.5.1"
 description = "Adapter to running ASGI applications on aiohttp"
 authors = ["Dmitry Orlov <me@mosquito.su>"]
 readme = "README.md"


### PR DESCRIPTION
If large request has no header Transfer-Encoding: chunked, aiohttp will read first chunk and return more_body flag as False (https://github.com/aio-libs/aiohttp/blob/master/aiohttp/streams.py#L411). That's why need use at_eof function for detect end of request body and empty buffer.