### PR TITLE
Fix aiohttp_asgi with aiohttp>=3.10.6...

### DIFF
--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -5,6 +5,7 @@ from typing import (
     Any, Awaitable, Callable, Coroutine, Dict, Generator, List, MutableMapping,
     Optional, Set, Tuple, Union,
 )
+from warnings import warn
 
 from aiohttp import ClientRequest, WSMessage, WSMsgType, hdrs
 from aiohttp.abc import AbstractMatchInfo, AbstractStreamWriter
@@ -116,17 +117,19 @@ class ASGIMatchInfo(AbstractMatchInfo):
             self._current_app = app
         self._apps.insert(0, app)
 
-    # @contextmanager
-    # def set_current_app(
-    #     self,
-    #     app: Application,
-    # ) -> Generator[None, None, None]:
-    #     prev = self._current_app
-    #     self._current_app = app
-    #     try:
-    #         yield
-    #     finally:
-    #         self._current_app = prev
+    @contextmanager
+    def set_current_app(
+        self,
+        app: Application,
+    ) -> Generator[None, None, None]:
+        warn("The set_current_app() context manager is deprecated, please use add_app() instead (https://github.com/mosquito/aiohttp-asgi/pull/11)!", DeprecationWarning)
+        prev = self._current_app
+        self.add_app(app)
+        try:
+            yield
+        finally:
+            self._current_app = prev
+            self._apps.pop(0)
 
     @property
     def current_app(self) -> "Application":

--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -125,6 +125,7 @@ class ASGIMatchInfo(AbstractMatchInfo):
         warn("The set_current_app() context manager is deprecated, please use add_app() instead (https://github.com/mosquito/aiohttp-asgi/pull/11)!", DeprecationWarning)
         prev = self._current_app
         self.add_app(app)
+        self._current_app = app
         try:
             yield
         finally:

--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -107,10 +107,10 @@ class ASGIMatchInfo(AbstractMatchInfo):
         return self._apps
 
     @property
-    def apps(self) -> Tuple["Application", ...]:
+    def apps(self) -> Tuple[Application, ...]:
         return tuple(self._apps)
 
-    def add_app(self, app: "Application") -> None:
+    def add_app(self, app: Application) -> None:
         if self._frozen:
             raise RuntimeError("Cannot change apps stack after .freeze() call")
         if self._current_app is None:
@@ -132,13 +132,13 @@ class ASGIMatchInfo(AbstractMatchInfo):
             self._apps.pop(0)
 
     @property
-    def current_app(self) -> "Application":
+    def current_app(self) -> Application:
         app = self._current_app
         assert app is not None
         return app
 
     @current_app.setter
-    def current_app(self, app: "Application") -> None:
+    def current_app(self, app: Application) -> None:
         if DEBUG:  # pragma: no cover
             if app not in self._apps:
                 raise RuntimeError(

--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -8,10 +8,12 @@ from typing import (
 
 from aiohttp import ClientRequest, WSMessage, WSMsgType, hdrs
 from aiohttp.abc import AbstractMatchInfo, AbstractStreamWriter
+from aiohttp.helpers import DEBUG
 from aiohttp.web import (
     AbstractResource, Application, HTTPException, Request, StreamResponse,
     WebSocketResponse,
 )
+from urllib.parse import unquote
 from yarl import URL
 
 
@@ -76,6 +78,7 @@ class ASGIMatchInfo(AbstractMatchInfo):
         self._handler = handler
         self._apps = list()     # type: _ApplicationColelctionType
         self._current_app: Optional[Application] = None
+        self._frozen = False
 
     @property
     def handler(self) -> Callable[[Request], Awaitable[StreamResponse]]:
@@ -102,27 +105,48 @@ class ASGIMatchInfo(AbstractMatchInfo):
             return tuple(self._apps)
         return self._apps
 
-    def add_app(self, app: Application) -> None:
-        if isinstance(self._apps, tuple):
-            raise RuntimeError("Frozen resource")
+    @property
+    def apps(self) -> Tuple["Application", ...]:
+        return tuple(self._apps)
 
-        self._apps.append(app)
+    def add_app(self, app: "Application") -> None:
+        if self._frozen:
+            raise RuntimeError("Cannot change apps stack after .freeze() call")
+        if self._current_app is None:
+            self._current_app = app
+        self._apps.insert(0, app)
+
+    # @contextmanager
+    # def set_current_app(
+    #     self,
+    #     app: Application,
+    # ) -> Generator[None, None, None]:
+    #     prev = self._current_app
+    #     self._current_app = app
+    #     try:
+    #         yield
+    #     finally:
+    #         self._current_app = prev
+
+    @property
+    def current_app(self) -> "Application":
+        app = self._current_app
+        assert app is not None
+        return app
+
+    @current_app.setter
+    def current_app(self, app: "Application") -> None:
+        if DEBUG:  # pragma: no cover
+            if app not in self._apps:
+                raise RuntimeError(
+                    "Expected one of the following apps {!r}, got {!r}".format(
+                        self._apps, app
+                    )
+                )
+        self._current_app = app
 
     def freeze(self) -> None:
-        self._apps = tuple(self.apps)
-
-    @contextmanager
-    def set_current_app(
-        self,
-        app: Application,
-    ) -> Generator[None, None, None]:
-        prev = self._current_app
-        self._current_app = app
-        try:
-            yield
-        finally:
-            self._current_app = prev
-
+        self._frozen = True
 
 _ResponseType = Optional[Union[StreamResponse, WebSocketResponse]]
 _WriterType = Optional[AbstractStreamWriter]
@@ -178,7 +202,15 @@ class ASGIContext:
         if self.is_websocket():
             result["type"] = "websocket"
             result["scheme"] = "wss" if self.request.secure else "ws"
-            result["subprotocols"] = []
+
+            # Decode websocket subprotocol options
+            subprotocols = []
+            for header, value in result["headers"]:
+                if header == b"sec-websocket-protocol":
+                    subprotocols = [
+                        x.strip() for x in unquote(value.decode("ascii")).split(",")
+                    ]
+            result["subprotocols"] = subprotocols
 
         return result
 
@@ -250,7 +282,7 @@ class ASGIContext:
             if self.start_response_event.is_set():
                 raise asyncio.InvalidStateError
 
-            self.response = WebSocketResponse()
+            self.response = WebSocketResponse(protocols=self.scope["subprotocols"])
             self.writer = await self.response.prepare(self.request)
             return
 


### PR DESCRIPTION
... with https://github.com/aio-libs/aiohttp/pull/9200, and forward websocket subprotocols from the request headers.

I probably shouldn't have mixed these two things, but this version works for me with
```
aiohttp==3.10.9
channels==4.1.0
Django==4.2.16
```
to run a [Django](https://www.djangoproject.com/) application with [Channels](https://channels.readthedocs.io/en/latest/) and web sockets as an `ASGIResource` from an aiohttp application.

Without this patch the following exception is raised:

```
[server-1] Traceback (most recent call last):
[server-1]   File "/usr/local/lib/python3.8/dist-packages/aiohttp/web_protocol.py", line 477, in _handle_request
[server-1]     resp = await request_handler(request)
[server-1]   File "/usr/local/lib/python3.8/dist-packages/aiohttp/web_app.py", line 559, in _handle
[server-1]     return await handler(request)
[server-1]   File "/usr/local/lib/python3.8/dist-packages/aiohttp/web_middlewares.py", line 114, in impl
[server-1]     prev = match_info.current_app
[server-1] AttributeError: 'ASGIMatchInfo' object has no attribute 'current_app'
```

From [aiohttp/CHANGES.rst](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#removals-and-backward-incompatible-breaking-changes-1):

> Improved middleware performance -- by [:user:`bdraco`](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#id222).
> 
> The `set_current_app` method was removed from `UrlMappingMatchInfo` because it is no longer used, and it was unlikely external caller would ever use it.
> 
> Related issues and pull requests on GitHub: [:issue:`9200`](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#id224).

Likely the changes are not backwards compatible to older versions of aiohttp as-is...

Related to https://github.com/mosquito/aiohttp-asgi/pull/2.