### PR TITLE
Fix "KeyError: 'body'" in ASGIContext.on_send()

### DIFF
--- a/aiohttp_asgi/resource.py
+++ b/aiohttp_asgi/resource.py
@@ -257,12 +257,15 @@ class ASGIContext:
         if payload["type"] == "http.response.body":
             if self.writer is None:
                 raise TypeError("Unexpected message %r" % payload, payload)
-
-            if payload.get("more_body", False):
-                await self.writer.write(payload["body"])
+            body = payload.get('body')
+            if body is None:
                 return
 
-            await self.writer.write_eof(payload["body"])
+            if payload.get("more_body", False):
+                await self.writer.write(body)
+                return
+
+            await self.writer.write_eof(body)
             return
 
         if payload["type"] == "websocket.send":


### PR DESCRIPTION
... when serving a [Django ASGI application](https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/) with `aiohttp_asgi`. 

Apparently `payload["body"]` may not be defined. A "final closing message" with only the `type` field is sent [here](https://github.com/django/django/blob/aafe320712c1c1f96326b03b63d2ee7e8e5928ca/django/core/handlers/asgi.py#L352-L353) for streaming responses:

```py
            # Final closing message.
            await send({"type": "http.response.body"})
```

Calling `self.writer.write(body)` with an empty body (`b""`) triggers a `Connection reset by peer: Cannot write to closing transport` warning to be logged. So rather send nothing.